### PR TITLE
fix: marketplace source path must start with ./

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "aws-agentcore-langgraph",
-      "source": ".",
+      "source": "./",
       "description": "Deploy LangGraph 1.0 agents on AWS Bedrock AgentCore with memory, gateway, and runtime integration",
       "version": "1.0.1",
       "author": {


### PR DESCRIPTION
## Summary

- Fix marketplace.json source field: "." → "./"
- Claude Code plugin schema requires source to start with "./"

🤖 Generated with [Claude Code](https://claude.com/claude-code)